### PR TITLE
Adding some additional functionality to make it easier to set up Bandit from pre-existing data

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 node_modules
-.idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+.idea

--- a/README.markdown
+++ b/README.markdown
@@ -32,12 +32,29 @@ Sample JavaScript:
 
     bandit.selectArm() // Arm 1 is more likely, so this probably returns 1
 
+If you have pre-existing data that you want to load, you can explicitly pass in data via constructor.
+The following creates a bandit with 3 arms 
+
+    var bandit = new Bandit({
+        arms: [{ count: 10, sum: 2 },
+                { count: 20, sum: 10 },
+                { count: 15: sum: 1}]
+    })
+
+You can also take advantage of the rewardMultiple function on the arms:
+
+    var bandit = new Bandit({ numberOfArms: 3 })
+    
+    bandit.arms[0].rewardMultiple(10, 2)  // Arm 0 wins 2 of 10 times
+    bandit.arms[1].rewardMultiple(20, 10) // Arm 1 wins 10 of 20 times 
+    bandit.arms[2].rewardMultiple(15, 1)  // Arm 2 wins 1 of 15 times
+
 #Unit Tests
 
-The unit tests use nodeunit.  You can set that up by typing:
+The unit tests use nodeunit, which should get installed with:
 
-    npm install -g nodeunit
+    npm install
 
 Then you can run unit tests with:
 
-    nodeunit tests.js
+    npm test

--- a/bayesian-bandit.js
+++ b/bayesian-bandit.js
@@ -6,42 +6,65 @@
   // Arm - one of the multi-armed bandit's arms, tracking observed rewards. //
   ////////////////////////////////////////////////////////////////////////////
 
+  /**
+   * @param {object} [args]
+   * @param {int} [args.count] - number of attempts on this arm
+   * @param {number} [args.sum] - total value accumulated on this arm
+   * @constructor
+     */
   function Arm(args) {
-    this.count = args && args.count || 0;
-    this.sum = args && args.sum || 0;
+    this.count = args && args.count || 0
+    this.sum = args && args.sum || 0
   }
 
-  Arm.prototype.count = 0
-
-  Arm.prototype.sum = 0
-
+  /**
+   * @param {number} value
+   *
+   * Increments number of attempts on the arm by one and the total accumulated
+   * value by value
+   */
   Arm.prototype.reward = function(value) {
 
     this.count++
     this.sum += value
   }
 
+  /**
+   * @param {int} numTries
+   * @param {number} totalValue
+   *
+   * Increments the number of attempts on the arm and the total value
+   * accumulated during those attempts.
+   */
   Arm.prototype.rewardMultiple = function(numTries, totalValue) {
     this.count += numTries
     this.sum += totalValue
   }
 
+  /**
+   * @returns {number} between 0 and 1
+   */
   Arm.prototype.sample = function() {
     return this.rbeta(1 + this.sum, 1 + this.count - this.sum)
   }
 
+  /**
+   * @param {int} a
+   * @param {int} b
+   * @returns {number} - number between 0 and 1
+   *
+   * Adapted from https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/d3bandits.js,
+   * which references Simulation and MC, Wiley.
+   *
+   * This apparently generates random numbers from a beta distribution:
+   * http://en.wikipedia.org/wiki/Beta_distribution
+   * I don't really know why this works -- it's just adapted from d3bandits.js
+   *
+   * For comparison, you might want to review the R project's rbeta code:
+   * https://svn.r-project.org/R/trunk/src/nmath/rbeta.c
+   *
+   */
   Arm.prototype.rbeta = function(a, b) {
-
-    // Adapted from https://github.com/CamDavidsonPilon/Probabilistic-Programming-and-Bayesian-Methods-for-Hackers/master/Chapter6_Priorities/d3bandits.js,
-    // which references Simulation and MC, Wiley.
-    //
-    // This apparently generates random numbers from a beta distribution:
-    // http://en.wikipedia.org/wiki/Beta_distribution
-    // I don't really know why this works
-    // -- it's just adapted from d3bandits.js.
-    //
-    // For comparison, you might want to review the R project's rbeta code:
-    // https://svn.r-project.org/R/trunk/src/nmath/rbeta.c
 
     var sum = a + b
       , ratio = a / b
@@ -74,21 +97,39 @@
   // Bandit - the n-armed bandit which selects arms from observed rewards. //
   ///////////////////////////////////////////////////////////////////////////
 
+  /**
+   * @param {object} [options]
+   * @param {Array.<{count: int, sum: number}>} [options.arms]
+   *      - Initialize the bandit with arms specified by the data provided
+   *
+   * @param {int} [options.numberOfArms]
+   *      - Initialize the bandit with a number of empty arms
+   *
+   * Note, only one of options.arms and options.numberOfArms should
+   * be provided.  If both are provided, options.arms takes precedence and
+   * numberOfArms will be ignored.
+   *
+   * @constructor
+     */
   function Bandit(options) {
 
     this.arms = []
 
-    if (!Array.isArray(options)) {
+    // If options.arms is explicitly passed, initialize the arms array with it
+    if (options && options.arms) {
+      for (var i = 0; i < options.arms.length; i++) {
+        this.arms.push(new Arm(options.arms[i]))
+      }
+    } else { // Otherwise initialize empty arms based on options.numberOfArms
       for (var a = 0; a < (options || {}).numberOfArms; a++) {
         this.arms.push(new Arm())
-      }
-    } else {
-      for (var i = 0; i < options.length; i++) {
-        this.arms.push(new Arm(options[i]))
       }
     }
   }
 
+  /**
+   * @returns {int} - index of the arm chosen by the bandit algorithm
+   */
   Bandit.prototype.selectArm = function() {
 
     var max = -Infinity

--- a/bayesian-bandit.js
+++ b/bayesian-bandit.js
@@ -6,7 +6,10 @@
   // Arm - one of the multi-armed bandit's arms, tracking observed rewards. //
   ////////////////////////////////////////////////////////////////////////////
 
-  function Arm() { }
+  function Arm(args) {
+    this.count = args && args.count || 0;
+    this.sum = args && args.sum || 0;
+  }
 
   Arm.prototype.count = 0
 
@@ -16,6 +19,11 @@
 
     this.count++
     this.sum += value
+  }
+
+  Arm.prototype.rewardMultiple = function(numTries, totalValue) {
+    this.count += numTries
+    this.sum += totalValue
   }
 
   Arm.prototype.sample = function() {
@@ -70,8 +78,14 @@
 
     this.arms = []
 
-    for(var a = 0; a < (options || {}).numberOfArms; a++) {
-      this.arms.push(new Arm())
+    if (!Array.isArray(options)) {
+      for (var a = 0; a < (options || {}).numberOfArms; a++) {
+        this.arms.push(new Arm())
+      }
+    } else {
+      for (var i = 0; i < options.length; i++) {
+        this.arms.push(new Arm(options[i]))
+      }
     }
   }
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,9 @@
     "type": "git",
     "url": "https://github.com/omphalos/bayesian-bandit.js.git"
   },
+  "scripts": {
+    "test": "NODE_ENV=test nodeunit tests.js"
+  },
   "keywords": [
     "machine",
     "learning",
@@ -25,5 +28,8 @@
   "engine": {
     "node": ">=0.8.17"
   },
-  "author": "omphalos"
+  "author": "omphalos",
+  "dependencies": {
+    "nodeunit": "^0.9.1"
+  }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/omphalos/bayesian-bandit.js.git"
   },
   "scripts": {
-    "test": "NODE_ENV=test nodeunit tests.js"
+    "test": "nodeunit tests.js"
   },
   "keywords": [
     "machine",
@@ -29,7 +29,7 @@
     "node": ">=0.8.17"
   },
   "author": "omphalos",
-  "dependencies": {
+  "devDependencies": {
     "nodeunit": "^0.9.1"
   }
 }

--- a/tests.js
+++ b/tests.js
@@ -32,8 +32,8 @@ module.exports = testCase({
 
       var arm = new Bandit.Arm()
 
-      arm.rewardMultiple(10, 2);
-      arm.rewardMultiple(15, 5);
+      arm.rewardMultiple(10, 2)
+      arm.rewardMultiple(15, 5)
 
       test.equal(arm.count, 25)
       test.equal(arm.sum, 7)
@@ -150,17 +150,24 @@ module.exports = testCase({
       test.done()
     },
 
-    'new Bandit with array should create the arms initialized properly': function(test) {
+    'new Bandit with options.arms should initialized arms properly': 
+        function(test) {
 
-      var bandit = new Bandit([{count: 100, sum: 20},{count: 50, sum: 30},{count:70, sum: 10}])
+      var bandit = new Bandit({
+        arms:[
+          {count: 100, sum: 20},
+          {count: 50,  sum: 30},
+          {count: 70,  sum: 10}
+        ]
+      })
 
       test.equal(bandit.arms.length, 3)
-      test.equal(bandit.arms[0].count, 100);
-      test.equal(bandit.arms[0].sum, 20);
-      test.equal(bandit.arms[1].count, 50);
-      test.equal(bandit.arms[1].sum, 30);
-      test.equal(bandit.arms[2].count, 70);
-      test.equal(bandit.arms[2].sum, 10);
+      test.equal(bandit.arms[0].count, 100)
+      test.equal(bandit.arms[0].sum, 20)
+      test.equal(bandit.arms[1].count, 50)
+      test.equal(bandit.arms[1].sum, 30)
+      test.equal(bandit.arms[2].count, 70)
+      test.equal(bandit.arms[2].sum, 10)
       test.done()
 
     },

--- a/tests.js
+++ b/tests.js
@@ -28,6 +28,18 @@ module.exports = testCase({
       test.done()
     },
 
+    'rewardMultiple should increase the sum and count': function(test) {
+
+      var arm = new Bandit.Arm()
+
+      arm.rewardMultiple(10, 2);
+      arm.rewardMultiple(15, 5);
+
+      test.equal(arm.count, 25)
+      test.equal(arm.sum, 7)
+      test.done()
+    },
+
     'sample should sample from the rbeta distribution': function(test) {
 
       var arm = new Bandit.Arm()
@@ -136,6 +148,21 @@ module.exports = testCase({
 
       test.equal(bandit.arms.length, 0)
       test.done()
+    },
+
+    'new Bandit with array should create the arms initialized properly': function(test) {
+
+      var bandit = new Bandit([{count: 100, sum: 20},{count: 50, sum: 30},{count:70, sum: 10}])
+
+      test.equal(bandit.arms.length, 3)
+      test.equal(bandit.arms[0].count, 100);
+      test.equal(bandit.arms[0].sum, 20);
+      test.equal(bandit.arms[1].count, 50);
+      test.equal(bandit.arms[1].sum, 30);
+      test.equal(bandit.arms[2].count, 70);
+      test.equal(bandit.arms[2].sum, 10);
+      test.done()
+
     },
 
     'selectArm should return the arm with the largest sample': function(test) {


### PR DESCRIPTION
Adding Arm.rewardMultiple to enable adding multiple counts / total reward to an arm

Adding a new form of constructor so you don't even have to call reward, you can simply initialize all the arms by passing in an array of {count, sum} objects

My specific use case:  running a multi-armed bandit test online for ad CTR.  I have views / clicks in the database and don't want to have to loop over reward(0)/reward(1) to get the bandit in the correct state.
